### PR TITLE
serial: fix flow flags

### DIFF
--- a/hooklib/serial.c
+++ b/hooklib/serial.c
@@ -544,12 +544,12 @@ static BOOL WINAPI my_SetCommState(HANDLE fd, const DCB *dcb)
         break;
 
     case RTS_CONTROL_ENABLE:
-        handflow.ControlHandShake |= SERIAL_RTS_CONTROL;
+        handflow.FlowReplace |= SERIAL_RTS_CONTROL;
 
         break;
 
     case RTS_CONTROL_HANDSHAKE:
-        handflow.ControlHandShake |= SERIAL_RTS_HANDSHAKE;
+        handflow.FlowReplace |= SERIAL_RTS_HANDSHAKE;
 
         break;
 


### PR DESCRIPTION
This fixes a misassignment of the RTS flags, which makes real VFDs break:

```
UART: Open COM port: 1
UART: Open COM port: 1
UART: Open COM port: 1
SERIAL_CTS_HANDSHAKE
SERIAL_DTR_CONTROL
SERIAL_RTS_HANDSHAKE
iohook_invoke_next IOCTL_SERIAL_SET_HANDFLOW FAIL 80070057
Runtime exception occurred.
File: D:\JenkinsWork\workspace\all_build\libs\libamw\src\amw_display_context.cpp
Line: 89
Function: enum am::util::ModuleContext<1>::Status __cdecl am::display::DisplayContext::initialize(void)
Message: ampdGd1232a01aInit(). ErrCode -5.
```

With serial hook disabled:
<img width="732" alt="mstsc_91PJjiYUHY" src="https://github.com/user-attachments/assets/f0cfed54-1c62-4f44-a00b-511d03f03b98">

With serial hook enabled:
<img width="521" alt="mstsc_y4Ro70VU1u" src="https://github.com/user-attachments/assets/fadf8cc3-6819-4e95-a1b8-ed3e9d3b222c">


This small adjustment fixes that.